### PR TITLE
Added MantineUI and Tailwind settings

### DIFF
--- a/src/lib/mantine/Button.tsx
+++ b/src/lib/mantine/Button.tsx
@@ -1,0 +1,19 @@
+import type { ButtonProps } from "@mantine/core"
+import { Button as MantineButton } from "@mantine/core"
+import React, { cloneElement, forwardRef } from "react"
+
+export const Button = forwardRef<
+  HTMLButtonElement,
+  ButtonProps & { dent?: boolean }
+>(({ dent, sx, ...props }, ref) => {
+  return cloneElement(<MantineButton />, {
+    sx: {
+      ...sx,
+      "&:not(:disabled):active": dent ? undefined : { transform: "none" },
+    },
+    ref,
+    ...props,
+  })
+})
+
+Button.displayName = "Button"

--- a/src/lib/mantine/index.ts
+++ b/src/lib/mantine/index.ts
@@ -1,0 +1,3 @@
+export { Button } from "./Button"
+export { useMediaQuery } from "./useMediaQuery"
+export { useViewportSize } from "./useViewportSize"

--- a/src/lib/mantine/useMediaQuery.ts
+++ b/src/lib/mantine/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useMediaQuery as useMediaQueryOriginal } from "@mantine/hooks"
+
+/* Mantineと一致させる */
+const map = {
+  xs: "576px",
+  sm: "768px",
+  md: "992px",
+  lg: "1200px",
+  xl: "1400px",
+} as const
+
+export const useMediaQuery = (
+  query: keyof typeof map,
+  initialValue: Parameters<typeof useMediaQueryOriginal>[1] = true,
+) => {
+  return useMediaQueryOriginal(`(min-width: ${map[query]})`, initialValue)
+}

--- a/src/lib/mantine/useViewportSize.ts
+++ b/src/lib/mantine/useViewportSize.ts
@@ -1,0 +1,13 @@
+import { useViewportSize as useViewportSizeOriginal } from "@mantine/hooks"
+import { useEffect, useState } from "react"
+
+export const useViewportSize = () => {
+  const [isMounted, setIsMounted] = useState(false)
+  const viewportSize = useViewportSizeOriginal()
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  return isMounted ? viewportSize : { width: undefined, height: undefined }
+}

--- a/src/lib/tailwind.css
+++ b/src/lib/tailwind.css
@@ -1,3 +1,2 @@
-@tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,4 +1,4 @@
-import "../styles/globals.css"
+import "../lib/tailwind.css"
 
 import { MantineProvider } from "@mantine/core"
 import type { AppPropsWithLayout } from "next/app"
@@ -16,7 +16,7 @@ export const App = ({ Component, pageProps }: AppPropsWithLayout) => {
 
   return (
     <Provider store={store}>
-      <MantineProvider>
+      <MantineProvider withGlobalStyles withNormalizeCSS>
         {getLayout(<Component {...pageProps} />)}
       </MantineProvider>
     </Provider>

--- a/src/pages/root/_/IndexBase.tsx
+++ b/src/pages/root/_/IndexBase.tsx
@@ -1,5 +1,10 @@
+import { Button } from "@src/lib/mantine/Button"
 import React from "react"
 
 export const IndexBase: React.FC = () => {
-  return <main>メインだよ</main>
+  return (
+    <main>
+      <Button>ボタン</Button>
+    </main>
+  )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,14 @@ module.exports = {
   ],
   theme: {
     extend: {},
+    // Mantine UI側のサイズに合わせる
+    screen: {
+      xs: "576px",
+      sm: "768px",
+      md: "992px",
+      lg: "1200px",
+      xl: "1400px",
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
# しまぶーさんのおすすめ設定を追加

## 実装内容
- Mantineボタンのクリックアニメーションを任意で付け外しできるように拡張
- MantineのuseMediaQueryをカスタマイズ
- MantineとTailwindのリセットCSSが競合しないように変更